### PR TITLE
Exit with success code when no process is found.

### DIFF
--- a/libexec/hr-freethousand
+++ b/libexec/hr-freethousand
@@ -14,5 +14,5 @@ if [ -n "$pid" ]; then
   kill $pid
 else
   echo "No process listening on port $port" >&2
-  exit 1
+  exit 0
 fi


### PR DESCRIPTION
Changing this message from `1` (failure) to `0` has the following benefits:
- More accurate: not finding a PID to kill is not a failure state
- Allows chaining the command with other commands (`freethousand && bundle && rails s`); current exit code breaks the chain if no server PID is found
